### PR TITLE
Updates to keep mooncoin-seeder version in sync with the mooncoin wal…

### DIFF
--- a/bitcoin.cpp
+++ b/bitcoin.cpp
@@ -298,7 +298,7 @@ bool TestNode(const CService &cip, int &ban, int &clientV, std::string &clientSV
 
 /*
 int main(void) {
-  CService ip("litecointools.com", 9333, true);
+  CService ip("moonypool", 44664, true);
   vector<CAddress> vAddr;
   vAddr.clear();
   int ban = 0;

--- a/combine.pl
+++ b/combine.pl
@@ -58,7 +58,7 @@ for my $file (@ARGV) {
 }
 
 for my $addr (sort { $res->{$b} <=> $res->{$a} } (keys %{$res})) {
-  if ($addr =~ /\A(\d+)\.(\d+)\.(\d+)\.(\d+):9333/) {
+  if ($addr =~ /\A(\d+)\.(\d+)\.(\d+)\.(\d+):44664/) {
     my $a = $1*0x1000000 + $2*0x10000 + $3*0x100 + $4;
     printf "0x%08x %s %g%%\n",$a,$addr,(1-((1-$res->{$addr}) ** (1/$n)))*100;
   }

--- a/db.h
+++ b/db.h
@@ -12,11 +12,11 @@
 
 #define MIN_RETRY 1000
 
-#define REQUIRE_VERSION 70002
+#define REQUIRE_VERSION 70016
 
 static inline int GetRequireHeight(const bool testnet = fTestNet)
 {
-    return testnet ? 2000 : 1150000;
+    return testnet ? 0 : 1240000;
 }
 
 std::string static inline ToString(const CService &ip) {

--- a/protocol.h
+++ b/protocol.h
@@ -3,6 +3,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
+
+
 #ifndef __cplusplus
 #error This header can only be compiled as C++.
 #endif


### PR DESCRIPTION
Updates to keep mooncoin-seeder version in sync with the mooncoin wallet version. 
This version should only accept client version 70016 or greater.
v0.13.9.0-b257fcdsegwit

